### PR TITLE
chore: consistent image name

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-IMAGE?=kameshsampath/drone-desktop-extension
+IMAGE?=kameshsampath/drone-desktop-docker-extension
 TAG?=latest
 
 BUILDER=buildx-multi-arch

--- a/docker/manifest.local.tmpl
+++ b/docker/manifest.local.tmpl
@@ -1,4 +1,4 @@
-image: kameshsampath/drone-desktop-extension:{{#if build.tag}}{{trimPrefix "v" build.tag}}{{else}}latest{{/if}}
+image: kameshsampath/drone-desktop-docker-extension:{{#if build.tag}}{{trimPrefix "v" build.tag}}{{else}}latest{{/if}}
 {{#if build.tags}}
 tags:
 {{#each build.tags}}
@@ -7,12 +7,12 @@ tags:
 {{/if}}
 manifests:
   -
-    image: kameshsampath/drone-desktop-extension:{{#if build.tag}}{{trimPrefix "v" build.tag}}-{{/if}}linux-amd64
+    image: kameshsampath/drone-desktop-docker-extension:{{#if build.tag}}{{trimPrefix "v" build.tag}}-{{/if}}linux-amd64
     platform:
       architecture: amd64
       os: linux
   -
-    image: kameshsampath/drone-desktop-extension:{{#if build.tag}}{{trimPrefix "v" build.tag}}-{{/if}}linux-arm64
+    image: kameshsampath/drone-desktop-docker-extension:{{#if build.tag}}{{trimPrefix "v" build.tag}}-{{/if}}linux-arm64
     platform:
       architecture: arm64
       os: linux

--- a/docker/manifest.tmpl
+++ b/docker/manifest.tmpl
@@ -1,4 +1,4 @@
-image: drone/drone-desktop-extension:{{#if build.tag}}{{trimPrefix "v" build.tag}}{{else}}latest{{/if}}
+image: drone/drone-desktop-docker-extension:{{#if build.tag}}{{trimPrefix "v" build.tag}}{{else}}latest{{/if}}
 {{#if build.tags}}
 tags:
 {{#each build.tags}}
@@ -7,12 +7,12 @@ tags:
 {{/if}}
 manifests:
   -
-    image: drone/drone-desktop-extension:{{#if build.tag}}{{trimPrefix "v" build.tag}}-{{/if}}linux-amd64
+    image: drone/drone-desktop-docker-extension:{{#if build.tag}}{{trimPrefix "v" build.tag}}-{{/if}}linux-amd64
     platform:
       architecture: amd64
       os: linux
   -
-    image: drone/drone-desktop-extension:{{#if build.tag}}{{trimPrefix "v" build.tag}}-{{/if}}linux-arm64
+    image: drone/drone-desktop-docker-extension:{{#if build.tag}}{{trimPrefix "v" build.tag}}-{{/if}}linux-arm64
     platform:
       architecture: arm64
       os: linux


### PR DESCRIPTION
fix the consistent image `drone-desktop-docker-extension` over `drone-desktop-extension`